### PR TITLE
Dockerfile added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+#
+# Meshtastic 2.0 to APRS-IS gateway
+# Please use your own aprs-is server and don't upstream it to public servers
+# You can use it i.e. with your own APRS Track Direct implementation
+#
+
+FROM python:3.9-alpine
+
+
+WORKDIR /opt/meshtastic-mqtt-aprs
+
+RUN apk add --no-cache git \
+ && git clone -b reworking_for_aprs https://github.com/erstec/meshtastic-mqtt-aprs.git . \
+ && pip3 install . \
+ && cd /tmp && rm -rf /opt/meshtastic-mqtt-aprs \
+ && apk del git
+
+# meshtastic install files can be removed after installation
+
+WORKDIR /tmp
+
+LABEL description="MeshTastic 2.0 MQTT to APRS gateway"
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["/usr/local/bin/python3","/usr/local/bin/meshtastic-mqtt-aprs"]


### PR DESCRIPTION
Initial Dockerfile. 
Unfortunately parameters are hardcoded in meshtastic_mqtt_aprs.py and this file should be mounted on top.